### PR TITLE
Add missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,24 @@ Microsserviço de catálogo
 #### Crie os containers com Docker
 
 ```bash
-$ docker-compose up
+$ docker-compose up -d
 ```
+
+#### Instale as dependências
+
+Primeiramente é necessário se conectar ao container:
+
+```bash
+docker-compose exec app bash
+```
+
+Agora podemos instalar as dependências:
+
+```bash
+composer install
+```
+
+> Deste momento em diante já podemos ter acesso ao `php artisan`
 
 #### Accesse no browser
 


### PR DESCRIPTION
O README.md sugere que basta rodar `docker-compose up` e na sequência acessar o endereço a aplicação, porém, isso não é bem verdade uma vez que é necessário instalar as dependências base...

Como forma de solução sugiro adicionar as instruções ausentes ao README.md.