### PR TITLE
[FIX] - Adicionando suporte para chipset Apple Silicon/M1

### DIFF
--- a/.docker/mysql/Dockerfile
+++ b/.docker/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.7
+FROM mariadb:10.7.1
 
 RUN usermod -u 1000 mysql


### PR DESCRIPTION
As atuais imagens do MySQL não oferecem suporte ao chipset M1 da Apple, como solução alternativa podemos utilizar o MariaDB que é um fork do MySQL com diversas melhorias, a mudança não causa impacto para o que utilizamos no curso.

Observação: A utilização da imagem do MySQL juntamente com a definição de `platform` dentro do arquivo `docker-compose` não corrige o problema de suporte para chipset M1.